### PR TITLE
Fixed compilation problems and memory issues

### DIFF
--- a/FCI/parallel/IdenticalParticles/src/PAR-shell-model.h
+++ b/FCI/parallel/IdenticalParticles/src/PAR-shell-model.h
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>
-#include <malloc.h>
 #include <string.h> 
 #include <time.h>
 #include <ctype.h>

--- a/FCI/parallel/pnCase/src/PAR-pnShellModel.h
+++ b/FCI/parallel/pnCase/src/PAR-pnShellModel.h
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>
-#include <malloc.h>
 #include <string.h> 
 #include <time.h>
 #include <ctype.h>

--- a/FCI/serial/IdenticalParticles/src/shell-model.h
+++ b/FCI/serial/IdenticalParticles/src/shell-model.h
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>
-
 #include <string.h> 
 #include <time.h>
 #include <ctype.h>

--- a/FCI/serial/pnCase/src/shell.h
+++ b/FCI/serial/pnCase/src/shell.h
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>
-/* #include <malloc.h>  */
 #include <string.h> 
 #include <time.h>
 #include <ctype.h>


### PR DESCRIPTION
A static function was without type specifier caused compilation errors with clang.
The inclusion of malloc.h doesn't work on mac, but was not necessary, so I removed them.
`char  text[5]; ` was too short to contain what sprintf() asked for, which caused memory issues.
Removed a compiled binary file.

An issue with github atm shows only 1 commit. This is 4 commits, so wait until they appear to merge.